### PR TITLE
Fix: for Safari directfile, `play()` even if seek is not finished

### DIFF
--- a/src/compat/call_play_even_if_seeking.ts
+++ b/src/compat/call_play_even_if_seeking.ts
@@ -1,0 +1,17 @@
+import { isSafariDesktop } from "./browser_detection";
+
+/**
+ * 2025-06-18: We saw that Safari sometimes just decide to keep being at
+ * `HTMLMediaElement.prototype.seeking === true` until we call
+ * `HTMLMediaElement.prototype.play()` at least for Directfile contents on
+ * Safari desktop (I didn't test the rest) though the RxPlayer often does the
+ * reverse: we wait for `seeking` to be set to `false` before calling `play()`
+ * to ensure smooth playback.
+ *
+ * This function allows to disable this lock for those devices.
+ * @param {boolean} isDirectfile
+ * @returns {boolean}
+ */
+export default function callPlayEvenIfSeeking(isDirectfile: boolean): boolean {
+  return isDirectfile && isSafariDesktop;
+}

--- a/src/main_thread/init/utils/initial_seek_and_play.ts
+++ b/src/main_thread/init/utils/initial_seek_and_play.ts
@@ -15,6 +15,7 @@
  */
 
 import type { IMediaElement } from "../../../compat/browser_compatibility_types";
+import callPlayEvenIfSeeking from "../../../compat/call_play_even_if_seeking";
 import canSeekDirectlyAfterLoadedMetadata from "../../../compat/can_seek_directly_after_loaded_metadata";
 import shouldValidateMetadata from "../../../compat/should_validate_metadata";
 import { MediaError } from "../../../errors";
@@ -206,7 +207,8 @@ export default function performInitialSeekAndPlay(
         playbackObserver.listen(
           (observation, stopListening) => {
             if (
-              observation.seeking === SeekingState.None &&
+              (callPlayEvenIfSeeking(isDirectfile) ||
+                observation.seeking === SeekingState.None) &&
               observation.rebuffering === null &&
               observation.readyState >= 1
             ) {


### PR DESCRIPTION
We noticed an issue on some devices - for the moment only seen with Safari desktop directfile (e.g. playing an HLS content in directfile through the RxPlayer) - where a deadlock is going on after we perform the initial seek

- Safari waits for playback to begin (e.g. by calling the `play()` method on the video tag) before loading content and resetting the video element's `seeking` attribute to `false`

- The RxPlayer waits for the `seeking` attribute to be set to `false` before calling `play()`, to ensure it has enough data to play reliably.

As this is an optimization and as in "directfile", the browser is the one often in charge of knowing when it has enough data to play anyway, I propose here to just disable this behavior for Safari desktop when playing a directfile content.