### PR TITLE
Don't destroy PeriodStream in some ambiguous "exact end time" cases

### DIFF
--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -174,6 +174,28 @@ export default function StreamOrchestrator(
         if (!enableOutOfBoundsCheck || !isOutOfPeriodList(time)) {
           return;
         }
+        const nextPeriod =
+          manifest.getPeriodForTime(time) ?? manifest.getNextPeriod(time);
+        const lastPeriodEnd = periodList.last()?.end;
+        if (
+          !isNullOrUndefined(lastPeriodEnd) &&
+          lastPeriodEnd === time &&
+          !isNullOrUndefined(nextPeriod) &&
+          nextPeriod.start > time
+        ) {
+          // There's a kind-of ambiguous situation when the position is exactly
+          // at a Period's end but the next Period starts later: Do we consider
+          // that to be an out-of-bounds from the `PeriodStream` linked to that
+          // former Period?
+          // Technically we could, but the rest of the RxPlayer (e.g. a
+          // `Manifest`) may treat it as a special case where the position is
+          // still linked to the former Period.
+          //
+          // To avoid issues, also consider this special case here. Considering
+          // the just-ended Period as still in-bound should not create issues
+          // anyway.
+          return;
+        }
 
         log.info(
           "Stream",
@@ -190,8 +212,6 @@ export default function StreamOrchestrator(
         currentCanceller = new TaskCanceller();
         currentCanceller.linkToSignal(orchestratorCancelSignal);
 
-        const nextPeriod =
-          manifest.getPeriodForTime(time) ?? manifest.getNextPeriod(time);
         if (nextPeriod === undefined) {
           log.warn("Stream", "The wanted position is not found in the Manifest.");
           enableOutOfBoundsCheck = true;

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -177,6 +177,11 @@ export default function StreamOrchestrator(
         const nextPeriod =
           manifest.getPeriodForTime(time) ?? manifest.getNextPeriod(time);
         const lastPeriodEnd = periodList.last()?.end;
+        log.warn("Stream", "!!!!!!!!!", {
+          lastPeriodEnd,
+          time,
+          nextStart: nextPeriod?.start,
+        });
         if (
           !isNullOrUndefined(lastPeriodEnd) &&
           lastPeriodEnd === time &&
@@ -194,6 +199,7 @@ export default function StreamOrchestrator(
           // To avoid issues, also consider this special case here. Considering
           // the just-ended Period as still in-bound should not create issues
           // anyway.
+          log.warn("Stream", "!!!!!!!!!!!!! Do not destroy");
           return;
         }
 

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -492,8 +492,17 @@ export default function StreamOrchestrator(
     // that Period.
     playbackObserver.listen(
       ({ position }, stopListeningObservations) => {
-        if (basePeriod.end !== undefined && position.getWanted() > basePeriod.end) {
+        if (basePeriod.end !== undefined && position.getWanted() >= basePeriod.end) {
           const nextPeriod = manifest.getPeriodAfter(basePeriod);
+
+          log.warn("Stream", "!!!!!!! We just ended the previous PeriodStream", {
+            basePeriodStart: basePeriod.start,
+            basePeriodEnd: basePeriod.end,
+            wantedPos: position.getWanted(),
+            polledPos: position.getPolled(),
+            nextPeriodStart: nextPeriod?.start,
+            nextPeriodEnd: nextPeriod?.end,
+          });
 
           // Handle special wantedPosition === basePeriod.end cases
           if (basePeriod.containsTime(position.getWanted(), nextPeriod)) {

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -493,6 +493,16 @@ export default function StreamOrchestrator(
     playbackObserver.listen(
       ({ position }, stopListeningObservations) => {
         if (basePeriod.end !== undefined && position.getWanted() >= basePeriod.end) {
+          log.warn(
+            "Stream",
+            "!!!!!!! All Periods start -> ",
+            manifest.periods.map((p) => p.start).join(", "),
+          );
+          log.warn(
+            "Stream",
+            "!!!!!!! All Periods end -> ",
+            manifest.periods.map((p) => p.end).join(", "),
+          );
           const nextPeriod = manifest.getPeriodAfter(basePeriod);
 
           log.warn("Stream", "!!!!!!! We just ended the previous PeriodStream", {

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -182,24 +182,9 @@ export default function StreamOrchestrator(
           time,
           nextStart: nextPeriod?.start,
         });
-        if (
-          !isNullOrUndefined(lastPeriodEnd) &&
-          lastPeriodEnd === time &&
-          !isNullOrUndefined(nextPeriod) &&
-          nextPeriod.start > time
-        ) {
-          // There's a kind-of ambiguous situation when the position is exactly
-          // at a Period's end but the next Period starts later: Do we consider
-          // that to be an out-of-bounds from the `PeriodStream` linked to that
-          // former Period?
-          // Technically we could, but the rest of the RxPlayer (e.g. a
-          // `Manifest`) may treat it as a special case where the position is
-          // still linked to the former Period.
-          //
-          // To avoid issues, also consider this special case here. Considering
-          // the just-ended Period as still in-bound should not create issues
-          // anyway.
-          log.warn("Stream", "!!!!!!!!!!!!! Do not destroy");
+        if (!isNullOrUndefined(nextPeriod) && periodList.has(nextPeriod)) {
+          // Last check just for resilience reasons that the wanted Period is
+          // not one of the handled ones
           return;
         }
 

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -492,7 +492,7 @@ export default function StreamOrchestrator(
     // that Period.
     playbackObserver.listen(
       ({ position }, stopListeningObservations) => {
-        if (basePeriod.end !== undefined && position.getWanted() >= basePeriod.end) {
+        if (basePeriod.end !== undefined && position.getWanted() > basePeriod.end) {
           const nextPeriod = manifest.getPeriodAfter(basePeriod);
 
           // Handle special wantedPosition === basePeriod.end cases

--- a/src/manifest/utils.ts
+++ b/src/manifest/utils.ts
@@ -139,7 +139,8 @@ export function getPeriodForTime(
   time: number,
 ): IPeriod | IPeriodMetadata | undefined {
   let nextPeriod = null;
-  for (const period of manifest.periods) {
+  for (let i = manifest.periods.length - 1; i >= 0; i--) {
+    const period = manifest.periods[i];
     if (periodContainsTime(period, time, nextPeriod)) {
       return period;
     }

--- a/src/manifest/utils.ts
+++ b/src/manifest/utils.ts
@@ -187,11 +187,21 @@ export function periodContainsTime(
   nextPeriod: IPeriodMetadata | null,
 ): boolean {
   if (time >= period.start && (period.end === undefined || time < period.end)) {
+    console.warn("!!!!!!!!!!!!!! CASE 1", "pe=", period.end, "time=", time);
     return true;
   } else if (
     time === period.end &&
     (nextPeriod === null || nextPeriod.start > period.end)
   ) {
+    console.warn(
+      "!!!!!!!!!!!!!! CASE 2",
+      "pe=",
+      period.end,
+      "nps",
+      nextPeriod?.start,
+      "time=",
+      time,
+    );
     // The last possible timed position of a Period is ambiguous as it is
     // frequently in common with the start of the next one: is it part of
     // the current or of the next Period?
@@ -199,6 +209,15 @@ export function periodContainsTime(
     // only one with that position.
     return true;
   }
+  console.warn(
+    "!!!!!!!!!!!!!! CASE 3",
+    "pe=",
+    period.end,
+    "nps",
+    nextPeriod?.start,
+    "time=",
+    time,
+  );
   return false;
 }
 


### PR DESCRIPTION
An issue, https://github.com/canalplus/rx-player/issues/1736, noticed that we may have an infinite rebuffering issue in the following conditions:

1. The position is exactly at a given Period's end

2. The next Period is not directly consecutive to that Period: it starts later.

In that situation, to which Period is linked the current position:
  - the former? (as it just ends at that exact point)
  - the latter? (as it should be the Period on which we'll focus from now)
  - none? (technically we may argue that no Period is linked to the position from now on)

Different RxPlayer modules had different opinions and we encountered an issue at least in the `StreamOrchestrator`:

  - The `Manifest` told us that this position belonged to the former Period (only in that specific case).

  - However the `StreamOrchestrator` thought that the position now went over the former Period and was now under the responsibility of the latter one.

We ended up creating and destroying modules linked to the former Period.

To fix this, I propose to just play nicer in the `StreamOrchestrator` by considering that in that special scenario, we can still consider the position as part of the former Period (in the "bound checking" code that previously was creating the issue).